### PR TITLE
add cache to `floatingPointBytesToInt` to reduce on-chain calls

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -105,6 +105,11 @@ type PendingCommitsByPoolCommitterAndInterval @entity {
   commitIds: [String!]!
 }
 
+type CachedConvertedBytesToUint @entity {
+  id: ID! # bytesHexString-decimals
+  value: BigInt!
+}
+
 enum CommitType {
   ShortMint
   ShortBurn

--- a/src/utils/helper.ts
+++ b/src/utils/helper.ts
@@ -2,7 +2,11 @@ import { Address, BigDecimal, BigInt, Bytes, log, TypedMap } from "@graphprotoco
 import { LeveragedPool,  } from "../../generated/templates/LeveragedPool/LeveragedPool";
 import { ERC20 } from "../../generated/templates/LeveragedPool/ERC20";
 import { PoolSwapLibrary } from "../../generated/templates/PoolCommitter/PoolSwapLibrary";
-import { LeveragedPool as LeveragedPoolEntity, LeveragedPoolByPoolCommitter } from "../../generated/schema"
+import {
+	LeveragedPool as LeveragedPoolEntity,
+	LeveragedPoolByPoolCommitter,
+	CachedConvertedBytesToUint
+} from "../../generated/schema"
 
 import { PoolCommitter, PoolKeeper } from "../../generated/templates"
 
@@ -81,12 +85,22 @@ export function formatDecimalUnits(value: BigDecimal, decimals: BigInt): BigDeci
 }
 
 export function floatingPointBytesToInt(bytes: Bytes, decimals: BigInt): BigInt {
+	const cacheId = bytes.toHexString()+'-'+decimals.toString();
+	const cachedResult = CachedConvertedBytesToUint.load(cacheId);
+
+	if(cachedResult) {
+		return cachedResult.value;
+	}
+
 	const poolSwapLibrary = PoolSwapLibrary.bind(poolSwapLibraryAddress);
 
-	// TODO: this still isn't quite right
-	const normalizer = BigInt.fromI32(1).times(BigInt.fromI32(10).pow(u8(decimals.toI32())))
+	const normalizer = BigInt.fromI32(10).pow(u8(decimals.toI32()))
 	const normalizedBytes = poolSwapLibrary.multiplyDecimalByUInt(bytes, normalizer);
 	const convertedBytes = poolSwapLibrary.convertDecimalToUInt(normalizedBytes);
+
+	const newCacheEntry = new CachedConvertedBytesToUint(cacheId);
+	newCacheEntry.value = convertedBytes;
+	newCacheEntry.save();
 
 	return convertedBytes
 }


### PR DESCRIPTION
# Motivation
on-chain calls have a large impact on sync times, they should be reduced where feasible

# Changes
cache results of converted floating point numbers to reduce calls to `poolSwapLibrary`